### PR TITLE
activated getPixelColor and used it for imageSize to return the color…

### DIFF
--- a/src/ImageInformation.py
+++ b/src/ImageInformation.py
@@ -35,7 +35,6 @@ def myFirstImageManipulation(img):
 #           Color of the first pixel in the second column
 #           This function should work for images with three channels
 
-
 def imageSize(img):
     width, height = img.shape[:2]
     print(f"Width: {width}, Height: {height}")


### PR DESCRIPTION
## Bugfix für die Pixel-Farbe – siehe Bug-Comments 🙂  

```python
def imageSize(img):
    width, height = img.shape[:2]
    print(f"Width: {width}, Height: {height}")
    print(f"Color of the first pixel: {getPixelColor(img[0][0])}")
    print(f"Color of the first pixel in the second row: {getPixelColor(img[1][0])}")
    print(f"Color of the first pixel in the second column: {getPixelColor(img[0][1])}")
    return [width, height]

def getPixelColor(pixel):
    return pixel.tolist()
```
Den Return so angepasst, dass jetzt wirklich der tatsächliche Farbwert des Pixels genommen wird, anstatt eines fixen Werts.

Hab auch bisschen getestet – gibt bis jetzt immer sinnvolle Werte aus. 